### PR TITLE
Adapt AsyncAPI version in Solace example

### DIFF
--- a/.github/workflows/automerge-orphans.yml
+++ b/.github/workflows/automerge-orphans.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   identify-orphans:
+    if: startsWith(github.repository, 'asyncapi/')
     name: Find orphans and notify
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -20,6 +20,7 @@ on:
 
 jobs:
   autoupdate-for-bot:
+    if: startsWith(github.repository, 'asyncapi/')
     name: Autoupdate autoapproved PR created in the upstream
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/help-command.yml
+++ b/.github/workflows/help-command.yml
@@ -25,7 +25,7 @@ jobs:
 
             - `/ready-to-merge` or `/rtm` - This comment will trigger automerge of PR in case all required checks are green, approvals in place and do-not-merge label is not added
             - `/do-not-merge` or `/dnm` - This comment will block automerging even if all conditions are met and ready-to-merge label is added
-            - `/autoupdate` or `/au` - This comment will add `autoupdate` label to the PR and keeps your PR up-to-date to the target branch's future changes. Unless there is a merge conflict.
+            - `/autoupdate` or `/au` - This comment will add `autoupdate` label to the PR and keeps your PR up-to-date to the target branch's future changes. Unless there is a merge conflict or it is a draft PR.
   create_help_comment_issue:
     if: ${{ !github.event.issue.pull_request && contains(github.event.comment.body, '/help') && github.actor != 'asyncapi-bot' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/link-check-cron.yml
+++ b/.github/workflows/link-check-cron.yml
@@ -11,6 +11,7 @@ on:
   
 jobs:
   External-link-validation-weekly:
+    if: startsWith(github.repository, 'asyncapi/')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/stale-issues-prs.yml
+++ b/.github/workflows/stale-issues-prs.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   stale:
+    if: startsWith(github.repository, 'asyncapi/')
     name: Mark issue or PR as stale
     runs-on: ubuntu-latest
     steps:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,10 +6,10 @@
 
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
 
+* @derberg @fmvilas @asyncapi-bot-eve
+
 /anypointmq/ @GeraldLoeffler
 /ibmmq/      @rcoppen
 /kafka/      @lbroudoux @dalelane
 /solace/     @damaru-inc @CameronRushton
 *.json       @KhudaDad414
-
-* @derberg @fmvilas @asyncapi-bot-eve

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at fmvilas@gmail.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/solace/README.md
+++ b/solace/README.md
@@ -113,7 +113,7 @@ channels:
       eventType:
         schema:
           type: string
-asyncapi: 2.0.0
+asyncapi: 2.4.0
 info:
   title: HRApp
   version: 0.0.1
@@ -156,7 +156,7 @@ channels:
       eventType:
         schema:
           type: string
-asyncapi: 2.0.0
+asyncapi: 2.4.0
 info:
   title: HRApp
   version: 0.0.1


### PR DESCRIPTION


<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Solace Binding Protocol has been included with release 2.3.0 of AsyncAPI,
with:
- https://github.com/asyncapi/spec/commit/88abbe0c86611f7e6a8f63cb37768ad45a51a761
- https://github.com/asyncapi/spec/pull/666

Thus, specification example should indicate at least this version.

---

Noticed by working on Solace Protocol support on https://bump.sh/asyncapi